### PR TITLE
Fix bad URLs reported by CI

### DIFF
--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -239,7 +239,7 @@ Thank you, and looking forward to your contributions!
 [Canonical's Sphinx starter pack]: https://github.com/canonical/sphinx-docs-starter-pack
 [Read the Docs]: https://about.readthedocs.com/
 [Kernel documentation GitHub repository]: https://github.com/canonical/kernel-docs
-[pull request (PR)]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requestsproposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
+[pull request (PR)]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
 [related issues, pull requests, and repositories]: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls
 [conventional commits]: https://www.conventionalcommits.org/
 [GitHub Issue]: https://github.com/canonical/kernel-docs/issues

--- a/docs/how-to/develop-customise/build-kernel-snap.md
+++ b/docs/how-to/develop-customise/build-kernel-snap.md
@@ -251,4 +251,4 @@ You are now ready to build the kernel snap.
 
 % LINKS
 [Ubuntu Wiki - Build your own kernel]: https://wiki.ubuntu.com/Kernel/BuildYourOwnKernel
-[Snap - Build environment options]: https://snapcraft.io/docs/build-options#heading--snapcraft
+[Snap - Build environment options]: https://snapcraft.io/docs/build-options#p-58836-destructive-mode


### PR DESCRIPTION
Some CI checks are currently failing because of bad external URLs. Fix them.