### PR TITLE
Add/fix instructions to patch_acceptance_criteria

### DIFF
--- a/docs/reference/patch_acceptance_criteria.rst
+++ b/docs/reference/patch_acceptance_criteria.rst
@@ -174,6 +174,11 @@ In case the upstream source is linux-next, you should explicit it::
 
     (cherry picked from commit 622f21994506e1dac7b8e4e362c8951426e032c5 linux-next)
 
+In case the upstream source is one of the stable trees, you should indicate
+which one the commit belongs to::
+
+     (cherry picked from commit e0aab7b07a9375337847c9d74a5ec044071e01c8 linux-4.19.y)
+
 In case the upstream source is another Ubuntu kernel (even a SAUCE patch), you
 can explicit it with the name of the source kernel::
 


### PR DESCRIPTION
- `git-cherry-pick` doesn't seem to have the `cover-letter` or `compose`options. For `git-send-email`, I believe `cover-letter` should suffice.
- Also add an example for patches that come from upstream stable trees.