### PR TITLE
glossary: fix link to dkms manpage

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -69,4 +69,4 @@ SRU
   of the system.
 ````
 
-[dkms manpages]: https://manpages.ubuntu.com/manpages/latest/en/man8/dkms.8.html
+[dkms manpages]: https://manpages.ubuntu.com/manpages/noble/en/man8/dkms.8.html


### PR DESCRIPTION
The CI reports 404 for the dkms manpage link:

    404 Client Error: Not Found for url:
    https://manpages.ubuntu.com/manpages/latest/en/man8/dkms.8.html

However when opening the link the browser redirects to the oracular man page instead of latest:

https://manpages.ubuntu.com/manpages/oracular/en/man8/dkms.8.html

This is probably because the manpages website returns a 404 with a Javascript or HTML redirect instead of a proper HTTP redirect.

To remove this warning redirect to the noble man page for the time being. The man pages tend to not evolve that much between releases so this is probably OK.