### PR TITLE
doc(reference/glossary): Add entry for SAUCE patches

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -68,6 +68,12 @@ OEM kernel
 
   See {doc}`/reference/oem-kernels` for more information.
 
+SAUCE
+  A SAUCE patch is a patch not included in Linus Torvalds' tree or linux-next, either because it hasn't
+  been pulled in, or because it is obtained from other non-upstream sources and is unlikely to be upstreamed.
+
+  See {doc}`/reference/patch-acceptance-criteria` for more information.
+
 SRU
   Stands for Stable Release Update, a process in distributions like Ubuntu used to provide important 
   updates to packages, including kernel packages, after the release of a stable version. SRUs deliver 


### PR DESCRIPTION
This adds a entry for the SAUCE patches in the glossary.

Policies regarding the SAUCE are more or less grey, and its definition may have implication on how people interpret our open source policy. Feel free to provide feedback if the definition here doesn't fit.