### PR TITLE
docs(how-to): add how to enable kernel source package repositories

### DIFF
--- a/docs/how-to/develop-customize/build-kernel.md
+++ b/docs/how-to/develop-customize/build-kernel.md
@@ -33,7 +33,7 @@ Otherwise, skip ahead to {ref}`how-to-build-kernel-obtain-source`.
 To build an Ubuntu kernel, you will need to enable the necessary source
 repositories in the `sources.list` or `ubuntu.sources` file.
 
-See {file}`/how-to/source-code/enable-source-repositories` for details.
+See {file}`</how-to/source-code/enable-source-repositories>` for details.
 
 (how-to-build-kernel-install-packages)=
 ### Install required packages

--- a/docs/how-to/develop-customize/build-kernel.md
+++ b/docs/how-to/develop-customize/build-kernel.md
@@ -33,59 +33,7 @@ Otherwise, skip ahead to {ref}`how-to-build-kernel-obtain-source`.
 To build an Ubuntu kernel, you will need to enable the necessary source
 repositories in the `sources.list` or `ubuntu.sources` file.
 
-````{only} docx
-+ Noble Numbat 24.04 (and newer)
-
-  Add "deb-src" to the `Types:` line in the `/etc/apt/sources.list.d/ubuntu.sources` file.
-
-  ```{code-block} shell
-  Types: deb deb-src
-  URIs: http://archive.ubuntu.com/ubuntu
-  Suites: noble noble-updates noble-backports
-  Components: main universe restricted multiverse
-  Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-  ```
-
-+ Mantic Minotaur 23.10 (and older)
-
-  Check that you have the following entries in the `/etc/apt/sources.list`
-  file. If not, add or uncomment these lines for your Ubuntu release.
-
-  ```{code-block} shell
-  deb-src http://archive.ubuntu.com/ubuntu jammy main
-  deb-src http://archive.ubuntu.com/ubuntu jammy-updates main
-  ```
-````
-
-``````{only} default
-`````{tab-set}
-````{tab-item} Noble Numbat 24.04 (and newer)
-
-Add "deb-src" to the `Types:` line in the `/etc/apt/sources.list.d/ubuntu.sources` file.
-
-```{code-block} shell
-:emphasize-lines: 1
-
-Types: deb deb-src
-URIs: http://archive.ubuntu.com/ubuntu
-Suites: noble noble-updates noble-backports
-Components: main universe restricted multiverse
-Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-```
-````
-
-````{tab-item} Mantic Minotaur 23.10 (and older)
-
-Check that you have the following entries in the `/etc/apt/sources.list`
-file. If not, add or uncomment these lines for your Ubuntu release.
-
-```{code-block} shell
-deb-src http://archive.ubuntu.com/ubuntu jammy main
-deb-src http://archive.ubuntu.com/ubuntu jammy-updates main
-```
-````
-`````
-``````
+See {file}`/how-to/source-code/enable-source-repositories` for details.
 
 (how-to-build-kernel-install-packages)=
 ### Install required packages

--- a/docs/how-to/source-code/enable-source-repositories.md
+++ b/docs/how-to/source-code/enable-source-repositories.md
@@ -6,9 +6,37 @@ This is provided via `deb-src` - a line in the {file}`sources.list` or {file}`ub
 
 ## Enable `deb-src`
 
+````{only} docx
++ Noble Numbat 24.04 (and newer)
+
+  Add "deb-src" to the `Types:` line in the `/etc/apt/sources.list.d/ubuntu.sources` file.
+
+  ```{code-block} shell
+  Types: deb deb-src
+  URIs: http://archive.ubuntu.com/ubuntu
+  Suites: noble noble-updates noble-backports
+  Components: main universe restricted multiverse
+  Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+  ```
+
++ Mantic Minotaur 23.10 (and older)
+
+  Check that you have the following entries in the `/etc/apt/sources.list`
+  file. If not, add or uncomment these lines for your Ubuntu release.
+
+  ```{code-block} shell
+  deb-src http://archive.ubuntu.com/ubuntu jammy main
+  deb-src http://archive.ubuntu.com/ubuntu jammy-updates main
+  ```
+````
+
+``````{only} default
 `````{tab-set}
 ````{tab-item} Noble Numbat 24.04 (and newer)
-```{code-block} text
+
+Add "deb-src" to the `Types:` line in the `/etc/apt/sources.list.d/ubuntu.sources` file.
+
+```{code-block} shell
 :emphasize-lines: 1
 
 Types: deb deb-src
@@ -18,18 +46,19 @@ Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 ```
 ````
-````{tab-item} Mantic Minotaur 23.10 (and older)
-Check that you have the following entries in the {file}`/etc/apt/sources.list` file.
-If not, add or uncomment these lines for your Ubuntu release.
-For example, for Jammy:
 
-```{code-block} text
+````{tab-item} Mantic Minotaur 23.10 (and older)
+
+Check that you have the following entries in the `/etc/apt/sources.list`
+file. If not, add or uncomment these lines for your Ubuntu release.
+
+```{code-block} shell
 deb-src http://archive.ubuntu.com/ubuntu jammy main
 deb-src http://archive.ubuntu.com/ubuntu jammy-updates main
 ```
 ````
 `````
-Add "deb-src" to the `Types:` line in the {file}`/etc/apt/sources.list.d/ubuntu.sources` file.
+``````
 
 ## Update package list
 

--- a/docs/how-to/source-code/enable-source-repositories.md
+++ b/docs/how-to/source-code/enable-source-repositories.md
@@ -4,10 +4,10 @@ If you want to build or modify an Ubuntu kernel package from source, you will fi
 This is provided via `deb-src` - a line in the {file}`sources.list` or {file}`ubuntu.sources` file that points to repositories containing source packages instead of pre-built binaries.
 `deb-src` will need to be enabled on your build machine.
 
-## Enable `deb-src` for Noble Numbat 24.04 (and newer)
+## Enable `deb-src`
 
-Add "deb-src" to the `Types:` line in the {file}`/etc/apt/sources.list.d/ubuntu.sources` file.
-
+`````{tab-set}
+````{tab-item} Noble Numbat 24.04 (and newer)
 ```{code-block} text
 :emphasize-lines: 1
 
@@ -17,9 +17,8 @@ Suites: noble noble-updates noble-backports
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 ```
-
-## Enable `deb-src` for Mantic Minotaur 23.10 (and older)
-
+````
+````{tab-item} Mantic Minotaur 23.10 (and older)
 Check that you have the following entries in the {file}`/etc/apt/sources.list` file.
 If not, add or uncomment these lines for your Ubuntu release.
 For example, for Jammy:
@@ -28,3 +27,15 @@ For example, for Jammy:
 deb-src http://archive.ubuntu.com/ubuntu jammy main
 deb-src http://archive.ubuntu.com/ubuntu jammy-updates main
 ```
+````
+`````
+Add "deb-src" to the `Types:` line in the {file}`/etc/apt/sources.list.d/ubuntu.sources` file.
+
+## Update package list
+
+Once you have updated {file}`sources.list` or {file}`ubuntu.sources`, update the package list for the changes to take effect:
+
+```{code-block} shell
+sudo apt update
+```
+

--- a/docs/how-to/source-code/enable-source-repositories.md
+++ b/docs/how-to/source-code/enable-source-repositories.md
@@ -1,0 +1,30 @@
+# How to enable kernel source package repositories
+
+If you want to build or modify an Ubuntu kernel package from source, you will first need the kernel source code.
+This is provided via `deb-src` - a line in the {file}`sources.list` or {file}`ubuntu.sources` file that points to repositories containing source packages instead of pre-built binaries.
+`deb-src` will need to be enabled on your build machine.
+
+## Enable `deb-src` for Noble Numbat 24.04 (and newer)
+
+Add "deb-src" to the `Types:` line in the {file}`/etc/apt/sources.list.d/ubuntu.sources` file.
+
+```{code-block} text
+:emphasize-lines: 1
+
+Types: deb deb-src
+URIs: http://archive.ubuntu.com/ubuntu
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+```
+
+## Enable `deb-src` for Mantic Minotaur 23.10 (and older)
+
+Check that you have the following entries in the {file}`/etc/apt/sources.list` file.
+If not, add or uncomment these lines for your Ubuntu release.
+For example, for Jammy:
+
+```{code-block} text
+deb-src http://archive.ubuntu.com/ubuntu jammy main
+deb-src http://archive.ubuntu.com/ubuntu jammy-updates main
+```

--- a/docs/how-to/source-code/index.md
+++ b/docs/how-to/source-code/index.md
@@ -8,4 +8,5 @@ preparing the kernel before the build process.
 :maxdepth: 1
 
 Obtain kernel source using Git <obtain-kernel-source-git>
+Enable kernel source package repositories <enable-source-repositories>
 ```


### PR DESCRIPTION
Move "how to enable deb-src" out of specific pages since it's a common setup that can standalone.
Thanks!