### PR TITLE
docs: fix linkchecks and add manpages_url

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,9 +289,10 @@ rst_epilog = """
 # NOTE: If set, adding ':manpage:' to an .rst file
 #       adds a link to the corresponding man section at the bottom of the page.
 
-# manpages_url = f'https://manpages.ubuntu.com/manpages/{codename}/en/' + \
-#     f'man{section}/{page}.{section}.html'
-
+manpages_url = (
+    "https://manpages.ubuntu.com/manpages/noble/en/"
+    + "man{section}/{page}.{section}.html"
+)
 
 # Specifies a reST snippet to be prepended to each .rst file
 # This defines a :center: role that centers table cell content.

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -52,7 +52,7 @@ repository.
 
 For general guidance, refer to the [starter pack guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/).
 
-For syntax help and guidelines, refer to the [Canonical style guides](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/).
+For syntax help and guidelines, refer to the [Canonical documentation style guides](https://docs.ubuntu.com/styleguide/en/).
 
 In structuring, the documentation employs the [Diátaxis](https://diataxis.fr/) approach.
 
@@ -236,8 +236,8 @@ Thank you, and looking forward to your contributions!
 
 <!-- LINKS -->
 
-[Ubuntu Code of Conduct]: https://ubuntu.com/community/ethos/code-of-conduct
-[Canonical contributor license agreement]: https://ubuntu.com/legal/contributors
+[Ubuntu Code of Conduct]: https://ubuntu.com/community/docs/ethos/code-of-conduct
+[Canonical contributor license agreement]: https://canonical.com/legal/contributors
 [Canonical's Sphinx starter pack]: https://github.com/canonical/sphinx-docs-starter-pack
 [Read the Docs]: https://about.readthedocs.com/
 [Kernel documentation GitHub repository]: https://github.com/canonical/kernel-docs

--- a/docs/how-to/develop-customise/build-kernel-snap.md
+++ b/docs/how-to/develop-customise/build-kernel-snap.md
@@ -251,4 +251,4 @@ You are now ready to build the kernel snap.
 
 % LINKS
 [Ubuntu Wiki - Build your own kernel]: https://wiki.ubuntu.com/Kernel/BuildYourOwnKernel
-[Snap - Build environment options]: https://snapcraft.io/docs/build-options#p-58836-destructive-mode
+[Snap - Build environment options]:  https://documentation.ubuntu.com/snapcraft/stable/reference/build-environment-options/

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,8 @@ new users
 
 ```{grid-item-card} [Reference](/reference/index)
 
-**Technical information** - specifications, APIs, architecture
+**Reference information** about submitting patches and their criteria, and
+other processes related to Ubuntu kernels.
 ```
 
 ```{grid-item-card} [Explanation](/explanation/index)
@@ -62,12 +63,8 @@ Kernel documentation is a member of the Ubuntu family. It’s an open source
 documentation project that warmly welcomes community contributions, suggestions,
 fixes and constructive feedback.
 
-* [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-* Get support
-* Join our online chat
+* [Code of conduct](https://ubuntu.com/community/docs/ethos/code-of-conduct)
 * [Contribute to kernel docs](/how-to/contribute)
-* Roadmap
-* Thinking about using Example Product for your next project? Get in touch!
 
 ```{toctree}
 :hidden:

--- a/docs/reference/kernel-upload-rights.rst
+++ b/docs/reference/kernel-upload-rights.rst
@@ -105,10 +105,10 @@ send an email to the `Ubuntu kernel-team mailing list`_ requesting your
 application be reviewed.
 
 You will then get a notification from the team about the scheduled Matrix
-meeting (`Ubuntu Kernel room`_ at matrix:ubuntu.com) where you will be
-interviewed and a vote regarding your membership will be taken.
-
-.. _Ubuntu Kernel room: https://matrix.to/#/#kernel:ubuntu.com
+meeting -- in the Ubuntu Kernel room
+(:spellexception:`https://matrix.to/#/#kernel:ubuntu.com` at matrix:ubuntu.com
+-- where you will be interviewed and a vote regarding your membership will be
+taken.
 
 As part of the interview you will be asked to briefly introduce yourself, so
 prepare a 2-3 line introduction beforehand to speed up the process. Only
@@ -122,5 +122,5 @@ ubuntu-kernel-uploaders team by an administrator.
 
 .. _devel-permissions mailing lists: https://lists.ubuntu.com/mailman/listinfo/devel-permissions
 .. _ubuntu-kernel-uploaders: https://launchpad.net/~ubuntu-kernel-uploaders
-.. _Ubuntu kernel git repositories: http://kernel.ubuntu.com/git
+.. _Ubuntu kernel git repositories: https://kernel.ubuntu.com/git
 .. _Ubuntu kernel-team mailing list: https://lists.ubuntu.com/mailman/listinfo/kernel-team

--- a/docs/reference/oem-kernels.rst
+++ b/docs/reference/oem-kernels.rst
@@ -131,9 +131,9 @@ Related topics
 
 .. LINKS
 
-.. _linux-oem-6.5: https://kernel.ubuntu.com/gitea/kernel/jammy-linux-oem/src/branch/oem-6.5-next
-.. _linux-oem-6.8: https://kernel.ubuntu.com/gitea/kernel/noble-linux-oem/src/branch/oem-6.8-next
-.. _linux-oem-6.11: https://kernel.ubuntu.com/gitea/kernel/noble-linux-oem/src/branch/oem-6.11-next
+.. _linux-oem-6.5: https://kernel.ubuntu.com/forgejo/kernel/jammy-linux-oem/src/branch/oem-6.5-next
+.. _linux-oem-6.8: https://kernel.ubuntu.com/forgejo/kernel/noble-linux-oem/src/branch/oem-6.8-next
+.. _linux-oem-6.11: https://kernel.ubuntu.com/forgejo/kernel/noble-linux-oem/src/branch/oem-6.11-next
 .. _Stable Updates Cycles: https://kernel.ubuntu.com/
-.. _jammy-linux-oem: https://kernel.ubuntu.com/gitea/kernel/jammy-linux-oem/pulls
-.. _noble-linux-oem: https://kernel.ubuntu.com/gitea/kernel/noble-linux-oem/pulls
+.. _jammy-linux-oem: https://kernel.ubuntu.com/forgejo/kernel/jammy-linux-oem/pulls
+.. _noble-linux-oem: https://kernel.ubuntu.com/forgejo/kernel/noble-linux-oem/pulls

--- a/docs/reference/patch-acceptance-criteria.rst
+++ b/docs/reference/patch-acceptance-criteria.rst
@@ -59,7 +59,7 @@ targeted to the kernels and series that the patch is aiming to lend.
 
 The bug description must follow the `SRU template`_.
 
-.. _SRU template: https://canonical-sru-docs.readthedocs-hosted.com/en/latest/reference/bug-template/
+.. _SRU template: https://documentation.ubuntu.com/sru/en/latest/reference/bug-template/
 
 See `this example Launchpad bug`_.
 
@@ -98,7 +98,7 @@ SRU cover letter
 
 The patch should come with a *cover letter* that has both a short link to the
 SRU bug and a copy of the *SRU Justification* from the bug. It can be generated
-using the ``--cover-letter`` option of the git-send-email_ command.
+using the ``--cover-letter`` option of the :manpage:`git-send-email(1)` command.
 
 Example cover letter::
 
@@ -159,18 +159,22 @@ Source
 
 The patches should have a *cherry picked from* or *backported from* line with
 the appropriate sha from the upstream. It can be generated using the
-``-x`` option of the git-cherry-pick_ command. This line should appear just
-before your *Signed-off-by*::
+``-x`` option of the :manpage:`git-cherry-pick(1)` command.
+This line should appear just before your *Signed-off-by* line.
 
-    (cherry picked from commit 622f21994506e1dac7b8e4e362c8951426e032c5)
+.. code-block:: text
 
-::
+   (cherry picked from commit 622f21994506e1dac7b8e4e362c8951426e032c5)
 
-    (backported from commit 622f21994506e1dac7b8e4e362c8951426e032c5)
+.. code-block:: text
 
-In case the upstream source is linux-next, you should explicit it::
+   (backported from commit 622f21994506e1dac7b8e4e362c8951426e032c5)
 
-    (cherry picked from commit 622f21994506e1dac7b8e4e362c8951426e032c5 linux-next)
+In case the upstream source is linux-next, you should explicit state it.
+
+.. code-block:: text
+
+   (cherry picked from commit 622f21994506e1dac7b8e4e362c8951426e032c5 linux-next)
 
 In case the upstream source is one of the stable trees, you should indicate
 which one the commit belongs to::
@@ -194,7 +198,7 @@ Signed-off-by
 
 The patches must have your Signed-off-by (SoB) as the last line, after the
 upstream cherry-picked line. It can be generated using the ``-s`` option of the
-git-cherry-pick_ command.
+:manpage:`git-cherry-pick(1)` command.
 
 If the patch is from yourself and already has your SoB, a new SoB must be
 added.
@@ -309,6 +313,3 @@ Lack of time
 Maintaining these patches, with all the arguments from above, will be
 time-consuming on our side, and we don’t have the resources to both do this
 and deliver a stable Linux OS
-
-.. _git-cherry-pick: https://manpages.ubuntu.com/manpages/trusty/en/man1/git-cherry-pick.1.html
-.. _git-send-email: https://manpages.ubuntu.com/manpages/trusty/en/man1/git-send-email.1.html

--- a/docs/reference/stable-patch-format.rst
+++ b/docs/reference/stable-patch-format.rst
@@ -392,4 +392,4 @@ Related topics
 .. _The Ubuntu lifecycle and release cadence: https://ubuntu.com/about/release-cycle
 .. _Discourse - Kernel configuration in Ubuntu: https://discourse.ubuntu.com/t/kernel-configuration-in-ubuntu/35857
 .. _KernelTeam/KernelUpdates: https://wiki.ubuntu.com/KernelTeam/KernelUpdates
-.. _ubuntu-check-commit: https://kernel.ubuntu.com/gitea/actions/ubuntu-check-commit/src/branch/main/ubuntu-check-commit
+.. _ubuntu-check-commit: https://kernel.ubuntu.com/forgejo/actions/ubuntu-check-commit/src/branch/main/ubuntu-check-commit


### PR DESCRIPTION
- updated links to avoid redirects during make linkcheck
- removed placeholder text in home page
- fixed broken URLs in multiple pages
- added manpages_url in conf.py to support inline manpage role