### PR TITLE
docs/reference: modernize contents for getting uploader rights

### DIFF
--- a/docs/reference/dkms-upload-rights.rst
+++ b/docs/reference/dkms-upload-rights.rst
@@ -14,8 +14,8 @@ There is one packageset per release. See for example the
 
 .. _Noble kernel-dkms packageset: https://ubuntu-archive-team.ubuntu.com/packagesets/noble/kernel-dkms
 .. _ubuntu-kernel-dkms-uploaders: https://launchpad.net/~ubuntu-kernel-dkms-uploaders
-.. _MOTU: https://wiki.ubuntu.com/UbuntuDevelopers#MOTU
-.. _Ubuntu Core Developer: https://wiki.ubuntu.com/UbuntuDevelopers#CoreDev
+.. _MOTU: https://documentation.ubuntu.com/project/who-makes-ubuntu/developers/dmb-joining-MOTU/#dmb-joining-motu
+.. _Ubuntu Core Developer: https://documentation.ubuntu.com/project/who-makes-ubuntu/developers/dmb-joining-core-dev/#dmb-joining-core-dev
 
 Adding packages to the packageset
 =================================
@@ -37,7 +37,7 @@ application details. Use the DeveloperApplicationTemplate_ to create your
 `PaoloPisati/DKMSUploadApplication`_.
 
 .. _PaoloPisati/DKMSUploadApplication: https://wiki.ubuntu.com/PaoloPisati/DKMSUploadApplication
-.. _DeveloperApplicationTemplate: https://wiki.ubuntu.com/UbuntuDevelopment/DeveloperApplicationTemplate
+.. _DeveloperApplicationTemplate: https://discourse.ubuntu.com/t/developer-application-template/66670
 
 Then, you will need to reserve a meeting with the `Developer Membership Board
 (DMB)`_ for applying [#]_. To do so, `edit the DMB agenda`_ to add yourself to a
@@ -48,7 +48,7 @@ free slot.
    ubuntu-kernel-dkms-uploaders_ Launchpad group. This means we have no team
    process to review applications and must delegate to the DMB.
 
-.. _edit the DMB agenda: https://wiki.ubuntu.com/DeveloperMembershipBoard/Agenda
+.. _edit the DMB agenda: https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634
 .. _ubuntu-kernel-uploaders: https://launchpad.net/~ubuntu-kernel-uploaders
 .. _has no admin: https://launchpad.net/~ubuntu-kernel-dkms-uploaders/+contactuser
-.. _Developer Membership Board (DMB): https://wiki.ubuntu.com/DeveloperMembershipBoard
+.. _Developer Membership Board (DMB): https://documentation.ubuntu.com/project/who-makes-ubuntu/councils/dmb/

--- a/docs/reference/dkms-upload-rights.rst
+++ b/docs/reference/dkms-upload-rights.rst
@@ -36,7 +36,7 @@ application details. Use the DeveloperApplicationTemplate_ to create your
 ``DKMSUploadApplication`` page. See for example
 `PaoloPisati/DKMSUploadApplication`_.
 
-.. _PaoloPisati/DKMSUploadApplication: https://wiki.ubuntu.com/PaoloPisati/DKMSUploadApplication
+.. _PaoloPisati/DKMSUploadApplication: https://github.com/ubuntu/wiki-archives/blob/2831413ef2d929fe020ff33b6bf3cdaa78dd40db/UbuntuWiki/P/PaoloPisati-DKMSUploadApplication.wiki
 .. _DeveloperApplicationTemplate: https://discourse.ubuntu.com/t/developer-application-template/66670
 
 Then, you will need to reserve a meeting with the `Developer Membership Board

--- a/docs/reference/kernel-upload-rights.rst
+++ b/docs/reference/kernel-upload-rights.rst
@@ -94,7 +94,7 @@ https://discourse.ubuntu.com/t/developer-application-template/66670
 
 An example application can also be seen at the following: 
 
-https://wiki.ubuntu.com/LuisHenriques/PerPackageUploaderApplication 
+https://github.com/ubuntu/wiki-archives/blob/2831413ef2d929fe020ff33b6bf3cdaa78dd40db/UbuntuWiki/L/LuisHenriques-PerPackageUploaderApplication.wiki 
 
 At least three existing ubuntu-kernel-uploaders members must confirm that they
 have worked with you sufficiently to assess your skills and verify that you meet

--- a/docs/reference/kernel-upload-rights.rst
+++ b/docs/reference/kernel-upload-rights.rst
@@ -90,7 +90,7 @@ Application template
 If you are interested in joining, start by preparing your application using the
 following template:
 
-https://wiki.ubuntu.com/Kernel/Dev/PPUApplicationTemplate
+https://discourse.ubuntu.com/t/developer-application-template/66670
 
 An example application can also be seen at the following: 
 


### PR DESCRIPTION
This pull request updates documentation links for kernel upload rights and DKMS upload rights application processes. The main changes are updating outdated wiki links to new documentation and discourse pages, and adding example application references from the old wiki to clarify how to use the templates.
