### PR TITLE
docs: Migrate pre-proposed article from Ubuntu Wiki

### DIFF
--- a/docs/explanation/kernel-lifecycle-sru.md
+++ b/docs/explanation/kernel-lifecycle-sru.md
@@ -1,0 +1,61 @@
+---
+myst:
+  html_meta:
+    description: "Ubuntu kernel terminology glossary. Find definitions for SRU, DKMS, HWE, edge kernels, and other kernel development terms. Quick reference guide."
+---
+
+# Ubuntu kernel SRU lifecycle
+
+Each Stable Release Update (SRU) cycle, kernels move through several stages
+from initial preparation and build testing through to final publication in the
+``-updates`` or ``-security`` pockets. Each stage adds more testing and
+confidence before the kernel reaches a broader audience.
+
+## Preparation
+
+The lifecycle begins when the kernel sources are prepared and cranked, uploading
+packages to the build PPA. The goal is to confirm that package generation is
+proceeding correctly. The kernel is not yet ready for testing at this point.
+
+## Build PPA and early testing
+
+Once built, the kernel undergoes early validation in the build PPA:
+
+- **boot-testing**: confirms the kernel boots
+- **abi-testing**: checks ABI compatibility
+- **sru-review**: review by the kernel SRU team
+- **new-review**: review by the Archive Admin team
+
+A kernel at this stage is a candidate only. It has not been signed with
+official Canonical keys and has not yet undergone broad testing.
+
+## Promote to -proposed
+
+Once early testing and reviews pass, the kernel is copied to ``-proposed``,
+passing through a signing PPA first if it contains artifacts that require
+signing. At this point the kernel is fully formed and all signed elements carry
+official Canonical keys.
+
+## Testing in -proposed
+
+With the kernel in ``-proposed``, formal testing begins:
+
+- **automated-testing**: Ubuntu Auto Package Testing (ADT)
+- **certification-testing**: testing on certified platforms in the
+  certification team's lab
+- **regression-testing**: CKCT testing in the kernel team lab
+- **verification-testing**: validation of individual bugs that have an original
+  report in Launchpad
+
+{spellexception}`Signoffs` are also collected here — from the security team, the kernel owner,
+and where needed, the kernel team internally.
+
+This is the main confidence-building phase. The kernel stays in ``-proposed``
+until all required tests and {spellexception}`signoffs` are complete.
+
+## Promote to -updates and -security
+
+Once testing is complete and the cycle is ready to release, the kernel is
+promoted to ``-updates`` and is considered ready for general use. If the
+security team's signoff indicates it is required, the kernel is also released
+to ``-security``.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Guides for Ubuntu kernel development. Learn how to obtain source code, build kernels, test in -proposed versions, and contribute to the documentation."
+    description: "Guides for Ubuntu kernel development. Learn how to obtain source code, build kernels, test pre-release versions, and contribute to the documentation."
 ---
 
 # How-to guides
@@ -19,7 +19,7 @@ Obtain kernel source for an Ubuntu release using Git </how-to/source-code/obtain
 Send patches to the mailing-list </how-to/source-code/send-patches>
 Build an Ubuntu Linux kernel </how-to/develop-customise/build-kernel>
 Build an Ubuntu Linux kernel snap </how-to/develop-customise/build-kernel-snap>
-Test pre-release Ubuntu kernels </how-to/testing-verification/test-kernel-in-proposed>
+Test pre-release Ubuntu kernels </how-to/testing-verification/test-pre-release-kernels>
 Contribute to kernel docs </how-to/contribute>
 ```
 
@@ -44,4 +44,4 @@ The steps to build a kernel is similar but may have slightly difference configur
 These guides relate to testing the kernel to ensure its stability and
 functionality before you push or release a patch.
 
-- [Test pre-release Ubuntu kernels](/how-to/testing-verification/test-kernel-in-proposed)
+- [Test pre-release Ubuntu kernels](/how-to/testing-verification/test-pre-release-kernels)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -19,7 +19,7 @@ Obtain kernel source for an Ubuntu release using Git </how-to/source-code/obtain
 Send patches to the mailing-list </how-to/source-code/send-patches>
 Build an Ubuntu Linux kernel </how-to/develop-customise/build-kernel>
 Build an Ubuntu Linux kernel snap </how-to/develop-customise/build-kernel-snap>
-Test kernels in -proposed </how-to/testing-verification/test-kernel-in-proposed>
+Test pre-release Ubuntu kernels </how-to/testing-verification/test-kernel-in-proposed>
 Contribute to kernel docs </how-to/contribute>
 ```
 
@@ -44,4 +44,4 @@ The steps to build a kernel is similar but may have slightly difference configur
 These guides relate to testing the kernel to ensure its stability and
 functionality before you push or release a patch.
 
-- [Test kernels in -proposed](/how-to/testing-verification/test-kernel-in-proposed)
+- [Test pre-release Ubuntu kernels](/how-to/testing-verification/test-kernel-in-proposed)

--- a/docs/how-to/testing-verification/test-kernel-in-proposed.md
+++ b/docs/how-to/testing-verification/test-kernel-in-proposed.md
@@ -6,18 +6,18 @@ myst:
 
 # How to test pre-release Ubuntu kernels
 
-After a kernel's sources are prepared by the Canonical Kernel Team, they are
-uploaded to public build PPAs for compilation and regression testing. Once
-built, you may download and test these kernels before migration to the -proposed
-pocket. It is worth mentionning however that adding these PPAs to a production
-system could cause failures to boot or regressions, and so is heavily
-discouraged.
+Pre-release Ubuntu kernels are available in the Canonical Kernel Team (CKT)
+build PPAs and `-proposed` pocket before they are published to `-updates`.
+To install these pre-release kernels you need to opt in, as neither source is
+enabled by default.
 
-Once testing and certification have concluded, the kernels are then copied to
-the -proposed pocket for testing before being published to -updates and
--security. You can download these pre-release kernels to install and test them
-before a stable release, and although they may still contain regressions, the
-kernels in -proposed are more stable as a result of the testing they undergo.
+This guide explains how to enable and test pre-release Ubuntu kernels, and how
+to report any regressions you find.
+
+```{caution}
+Kernels published to the build PPAs are not suitable for production systems -
+enabling them could cause boot failures or regressions and is not recommended.
+```
 
 ## Enable the -proposed pocket to software sources
 
@@ -62,9 +62,9 @@ Add "\<series\>-proposed" (e.g. "jammy-proposed") to the following line in:
 ````
 `````
 
-## Enable a CKT Build PPA
+## Enable the CKT build PPA
 
-You may add the build PPAs to your system as follows:
+You can add the CKT build PPAs to your system as follows:
 
 ```{code-block} none
 sudo add-apt-repository ppa:canonical-kernel-team/ppa
@@ -72,9 +72,9 @@ sudo add-apt-repository ppa:canonical-kernel-team/ppa2
 ```
 
 ```{warning}
-Do remember that these kernels may be entirely untested at time of
-download and thus potentially fundamentally broken. Only test from build PPAs
-if you have a reason to do so.
+Do remember that these kernels may be entirely untested at time of download and
+thus potentially fundamentally broken. Only test from build PPAs if you have a
+reason to do so.
 ```
 
 ## Install the pre-release kernel

--- a/docs/how-to/testing-verification/test-kernel-in-proposed.md
+++ b/docs/how-to/testing-verification/test-kernel-in-proposed.md
@@ -4,12 +4,20 @@ myst:
     description: "Learn to enable -proposed pocket, install test kernels, and verify stability of kernels before release."
 ---
 
-# How to test kernels in -proposed
+# How to test pre-release Ubuntu kernels
 
-Ubuntu kernels are uploaded to the -proposed pocket for testing before being
-published to -updates and -security. You can download these pre-release kernels
-to install and test them before a stable release, but you must opt in to package
-from -proposed as they are not enabled by default.
+After a kernel's sources are prepared by the Canonical Kernel Team, they are
+uploaded to public build PPAs for compilation and regression testing. Once
+built, you may download and test these kernels before migration to the -proposed
+pocket. It is worth mentionning however that adding these PPAs to a production
+system could cause failures to boot or regressions, and so is heavily
+discouraged.
+
+Once testing and certification have concluded, the kernels are then copied to
+the -proposed pocket for testing before being published to -updates and
+-security. You can download these pre-release kernels to install and test them
+before a stable release, and although they may still contain regressions, the
+kernels in -proposed are more stable as a result of the testing they undergo.
 
 ## Enable the -proposed pocket to software sources
 
@@ -53,6 +61,21 @@ Add "\<series\>-proposed" (e.g. "jammy-proposed") to the following line in:
   ```
 ````
 `````
+
+## Enable a CKT Build PPA
+
+You may add the build PPAs to your system as follows:
+
+```{code-block} none
+sudo add-apt-repository ppa:canonical-kernel-team/ppa
+sudo add-apt-repository ppa:canonical-kernel-team/ppa2
+```
+
+```{warning}
+Do remember that these kernels may be entirely untested at time of
+download and thus potentially fundamentally broken. Only test from build PPAs
+if you have a reason to do so.
+```
 
 ## Install the pre-release kernel
 

--- a/docs/how-to/testing-verification/test-pre-release-kernels.md
+++ b/docs/how-to/testing-verification/test-pre-release-kernels.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Learn to enable -proposed pocket, install test kernels, and verify stability of kernels before release."
+    description: "Learn to enable the build PPAs and -proposed pocket, install test kernels, and verify stability of kernels before the release."
 ---
 
 # How to test pre-release Ubuntu kernels
@@ -18,6 +18,8 @@ to report any regressions you find.
 Kernels published to the build PPAs are not suitable for production systems -
 enabling them could cause boot failures or regressions and is not recommended.
 ```
+
+For details on the kernel lifecycle, see the {doc}`/explanation/kernel-lifecycle-sru`.
 
 ## Enable the -proposed pocket to software sources
 
@@ -46,7 +48,7 @@ Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 ```
 ````
-````{tab-item} Mantic Minotaur 23.10 (and older)
+````{tab-item} Jammy Jellyfish 22.04 (and older)
 
 Add "\<series\>-proposed" (e.g. "jammy-proposed") to the following line in:
 
@@ -74,7 +76,7 @@ sudo add-apt-repository ppa:canonical-kernel-team/ppa2
 ```{warning}
 Do remember that these kernels may be entirely untested at time of download and
 thus potentially fundamentally broken. Only test from build PPAs if you have a
-reason to do so.
+reason to do so. Do not test from build PPAs if you have Secure Boot enabled.
 ```
 
 ## Install the pre-release kernel

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,9 @@ processes for customization and maintenance.
 * - **Contributing to Ubuntu kernels**
   - {doc}`/reference/patch-acceptance-criteria` • {doc}`/reference/stable-patch-format` • {doc}`/how-to/source-code/send-patches`
 * - **Kernel development**
-  - {doc}`/how-to/source-code/enable-source-repositories` • {doc}`/how-to/source-code/obtain-kernel-source-git` • {doc}`/how-to/develop-customise/build-kernel` • {doc}`/how-to/develop-customise/build-kernel-snap` • {doc}`/how-to/testing-verification/test-kernel-in-proposed` • {doc}`/explanation/ubuntu-linux-kernel-sources`
+  - {doc}`/how-to/source-code/enable-source-repositories` • {doc}`/how-to/source-code/obtain-kernel-source-git` • {doc}`/how-to/develop-customise/build-kernel` • {doc}`/how-to/develop-customise/build-kernel-snap` • {doc}`/how-to/testing-verification/test-pre-release-kernels` • {doc}`/explanation/ubuntu-linux-kernel-sources`
 * - **Kernel release and maintenance**
-  - {doc}`/reference/kernel-workflow-playbook/kernel-release` • {doc}`/reference/kernel-workflow-playbook/kernel-rollback`
+  - {doc}`/explanation/kernel-lifecycle-sru` • {doc}`/reference/kernel-workflow-playbook/kernel-release` • {doc}`/reference/kernel-workflow-playbook/kernel-rollback`
 * - **Kernel variants**
   - {doc}`/explanation/stable-release-updates` • {doc}`/explanation/post-release-updates` • {doc}`/reference/hwe-kernels` • {doc}`/reference/oem-kernels` • {doc}`/reference/ubuntu-kernels/`
 * - **Upload rights**


### PR DESCRIPTION
Moved and updated pre-proposed information from the [Ubuntu Wiki article](https://wiki.ubuntu.com/Kernel/Dev/KernelTesting).