### PR TITLE
docs(reference): add upstream kernel patch tools to acceptance criteria

### DIFF
--- a/docs/reference/patch-acceptance-criteria.rst
+++ b/docs/reference/patch-acceptance-criteria.rst
@@ -48,6 +48,24 @@ Patch does not apply
 The patch should always be based on a recent kernel. Expect to resubmit
 again if the tip changes and the patch has conflicts.
 
+Patch fails upstream checks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Patches are expected to pass the upstream kernel patch tools provided with the
+kernel source tree. A patch that fails these checks will be rejected.
+
+Before you submit, do the following:
+
+- Read ``Documentation/process/submitting-patches.rst`` for the upstream
+  patch submission guidelines.
+- Run ``scripts/checkpatch.pl`` against a generated patch to catch style
+  and formatting problems.
+- Run ``scripts/cleanpatch`` if the patch needs to be cleaned before
+  submission.
+- Run ``scripts/cleanfile`` on a new file before you create the patch.
+- Run ``scripts/Lindent`` if a file needs to follow the kernel indentation
+  style.
+
 SRU patches
 -----------
 


### PR DESCRIPTION
Migrate the patch verification tools section from the deprecated Ubuntu Wiki page Kernel/Dev/KernelGitGuide into the patch acceptance criteria reference.

The added section lists the upstream kernel tools used to check patches before submission:
- Documentation/process/submitting-patches.rst
- scripts/checkpatch.pl
- scripts/cleanpatch
- scripts/cleanfile
- scripts/Lindent

The remaining content of KernelGitGuide is obsoleted by existing content.

- [x] Added or updated meta description (if this PR includes documentation changes)
- [x] Reviewed all GitHub Actions / CI results; any unresolved failures are explained in a comment

-----
