### PR TITLE
docs(how-to): reference mainline git repo for reference

### DIFF
--- a/docs/how-to/source-code/obtain-kernel-source-git.md
+++ b/docs/how-to/source-code/obtain-kernel-source-git.md
@@ -45,7 +45,7 @@ by first downloading the upstream kernel tree and using it as a reference for
 subsequent clones:
 
 ```{code-block} shell
-git clone https://kernel.ubuntu.com/ubuntu/linux.git
+git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 git clone --reference linux https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/jammy
 git clone --reference linux https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble
 ```


### PR DESCRIPTION
Replace kernel.ubuntu.com/ubuntu/linux.git with mainline Linux repo instead since there is no distinction between the versions, especially for development workflows.

- [x] Added or updated meta description (if this PR includes documentation changes)
- [x] Reviewed all GitHub Actions / CI results; any unresolved failures are explained in a comment

-----
